### PR TITLE
Features/com3d2

### DIFF
--- a/ExternalSaveData/ExSaveData.cs
+++ b/ExternalSaveData/ExSaveData.cs
@@ -18,19 +18,6 @@ namespace CM3D2.ExternalSaveData.Managed
         // 通常のプラグインは "CM3D2～" のように英数字から始まる名前をつけること
         const string CallbackName = ".CM3D2 ExternalSaveData";
 
-        private static object GetMaidStatus(Maid maid) {
-            var type = maid.GetType();
-            PropertyInfo pi = type.GetProperty("Param");
-            var param = (pi != null ? pi.GetValue(maid, null) : maid);
-            return param.GetType().GetProperty("status").GetValue(param, null);
-        }
-
-        private static object GetMaidStatusValue(Maid maid, String propkey) {
-            var status = GetMaidStatus(maid);
-            PropertyInfo pi = status.GetType().GetProperty(propkey);
-            return pi.GetValue(status, null);
-        }
-
         /// <summary>
         /// 拡張セーブデータ内の設定を得る(文字列)
         /// <para>指定した設定が存在しない場合はdefaultValueを返す</para>
@@ -53,7 +40,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 SetMaid(maid);
             }
-            return PluginSettings.Get((string)GetMaidStatusValue(maid, "guid"), pluginName, propName, defaultValue);
+            return PluginSettings.Get((string)Helper.GetMaidStatusValue(maid, "guid"), pluginName, propName, defaultValue);
         }
 
         public static bool GetBool(Maid maid, string pluginName, string propName, bool defaultValue)
@@ -100,7 +87,7 @@ namespace CM3D2.ExternalSaveData.Managed
                     return false;
                 }
             }
-            return PluginSettings.Set((string)GetMaidStatusValue(maid, "guid"), pluginName, propName, value);
+            return PluginSettings.Set((string)Helper.GetMaidStatusValue(maid, "guid"), pluginName, propName, value);
         }
 
         public static bool SetBool(Maid maid, string pluginName, string propName, bool value, bool overwrite)
@@ -159,7 +146,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return false;
             }
-            return PluginSettings.Remove((string)GetMaidStatusValue(maid, "guid"), pluginName, propName);
+            return PluginSettings.Remove((string)Helper.GetMaidStatusValue(maid, "guid"), pluginName, propName);
         }
 
         /// <summary>
@@ -179,7 +166,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 SetMaid(maid);
             }
-            return PluginSettings.Contains((string)GetMaidStatusValue(maid, "guid"), pluginName, propName);
+            return PluginSettings.Contains((string)Helper.GetMaidStatusValue(maid, "guid"), pluginName, propName);
         }
 
         /// <summary>
@@ -193,7 +180,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return false;
             }
-            return PluginSettings.ContainsMaid((string)GetMaidStatusValue(maid, "guid"));
+            return PluginSettings.ContainsMaid((string)Helper.GetMaidStatusValue(maid, "guid"));
         }
 
         /// <summary>
@@ -207,7 +194,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return;
             }
-            var s = GetMaidStatus(maid);
+            var s = Helper.GetMaidStatus(maid);
             var t = s.GetType();
             string[] cm3d2keys = { "last_name", "first_name", "create_time" },  com3d2keys = { "lastName", "firstName", "creationTime" };
             string[] keys = t.GetProperty("lastName") != null ? com3d2keys : cm3d2keys;
@@ -234,7 +221,7 @@ namespace CM3D2.ExternalSaveData.Managed
             for (int i = 0, n = cm.GetStockMaidCount(); i < n; i++)
             {
                 Maid maid = cm.GetStockMaid(i);
-                guids.Add((string)GetMaidStatusValue(maid, "guid"));
+                guids.Add((string)Helper.GetMaidStatusValue(maid, "guid"));
             }
             CleanupMaids(guids);
         }
@@ -412,7 +399,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return false;
             }
-            var s = GetMaidStatus(maid);
+            var s = Helper.GetMaidStatus(maid);
             var t = s.GetType();
             string[] cm3d2keys = { "last_name", "first_name", "create_time" },  com3d2keys = { "lastName", "firstName", "creationTime" };
             string[] keys = t.GetProperty("lastName") != null ? com3d2keys : cm3d2keys;

--- a/ExternalSaveData/ExSaveData.cs
+++ b/ExternalSaveData/ExSaveData.cs
@@ -18,6 +18,19 @@ namespace CM3D2.ExternalSaveData.Managed
         // 通常のプラグインは "CM3D2～" のように英数字から始まる名前をつけること
         const string CallbackName = ".CM3D2 ExternalSaveData";
 
+        private static object GetMaidStatus(Maid maid) {
+            var type = maid.GetType();
+            PropertyInfo pi = type.GetProperty("Param");
+            var param = (pi != null ? pi.GetValue(maid, null) : maid);
+            return param.GetType().GetProperty("status").GetValue(param, null);
+        }
+
+        private static object GetMaidStatusValue(Maid maid, String propkey) {
+            var status = GetMaidStatus(maid);
+            PropertyInfo pi = status.GetType().GetProperty(propkey);
+            return pi.GetValue(status, null);
+        }
+
         /// <summary>
         /// 拡張セーブデータ内の設定を得る(文字列)
         /// <para>指定した設定が存在しない場合はdefaultValueを返す</para>
@@ -40,7 +53,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 SetMaid(maid);
             }
-            return PluginSettings.Get(maid.Param.status.guid, pluginName, propName, defaultValue);
+            return PluginSettings.Get((string)GetMaidStatusValue(maid, "guid"), pluginName, propName, defaultValue);
         }
 
         public static bool GetBool(Maid maid, string pluginName, string propName, bool defaultValue)
@@ -87,7 +100,7 @@ namespace CM3D2.ExternalSaveData.Managed
                     return false;
                 }
             }
-            return PluginSettings.Set(maid.Param.status.guid, pluginName, propName, value);
+            return PluginSettings.Set((string)GetMaidStatusValue(maid, "guid"), pluginName, propName, value);
         }
 
         public static bool SetBool(Maid maid, string pluginName, string propName, bool value, bool overwrite)
@@ -146,7 +159,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return false;
             }
-            return PluginSettings.Remove(maid.Param.status.guid, pluginName, propName);
+            return PluginSettings.Remove((string)GetMaidStatusValue(maid, "guid"), pluginName, propName);
         }
 
         /// <summary>
@@ -166,7 +179,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 SetMaid(maid);
             }
-            return PluginSettings.Contains(maid.Param.status.guid, pluginName, propName);
+            return PluginSettings.Contains((string)GetMaidStatusValue(maid, "guid"), pluginName, propName);
         }
 
         /// <summary>
@@ -180,7 +193,7 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return false;
             }
-            return PluginSettings.ContainsMaid(maid.Param.status.guid);
+            return PluginSettings.ContainsMaid((string)GetMaidStatusValue(maid, "guid"));
         }
 
         /// <summary>
@@ -194,8 +207,14 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return;
             }
-            var s = maid.Param.status;
-            PluginSettings.SetMaid(s.guid, s.last_name, s.first_name, s.create_time);
+            var s = GetMaidStatus(maid);
+            var t = s.GetType();
+            string[] cm3d2keys = { "last_name", "first_name", "create_time" },  com3d2keys = { "lastName", "firstName", "creationTime" };
+            string[] keys = t.GetProperty("lastName") != null ? com3d2keys : cm3d2keys;
+            PluginSettings.SetMaid((string)t.GetProperty("guid").GetValue(s, null),
+                                   (string)t.GetProperty(keys[0]).GetValue(s, null),
+                                   (string)t.GetProperty(keys[1]).GetValue(s, null),
+                                   (string)t.GetProperty(keys[2]).GetValue(s, null));
         }
 
         /// <summary>
@@ -215,7 +234,7 @@ namespace CM3D2.ExternalSaveData.Managed
             for (int i = 0, n = cm.GetStockMaidCount(); i < n; i++)
             {
                 Maid maid = cm.GetStockMaid(i);
-                guids.Add(maid.Param.status.guid);
+                guids.Add((string)GetMaidStatusValue(maid, "guid"));
             }
             CleanupMaids(guids);
         }
@@ -393,8 +412,14 @@ namespace CM3D2.ExternalSaveData.Managed
             {
                 return false;
             }
-            var s = maid.Param.status;
-            return PluginSettings.SetMaidName(s.guid, s.last_name, s.first_name, s.create_time);
+            var s = GetMaidStatus(maid);
+            var t = s.GetType();
+            string[] cm3d2keys = { "last_name", "first_name", "create_time" },  com3d2keys = { "lastName", "firstName", "creationTime" };
+            string[] keys = t.GetProperty("lastName") != null ? com3d2keys : cm3d2keys;
+            return PluginSettings.SetMaidName((string)t.GetProperty("guid").GetValue(s, null),
+                                              (string)t.GetProperty(keys[0]).GetValue(s, null),
+                                              (string)t.GetProperty(keys[1]).GetValue(s, null),
+                                              (string)t.GetProperty(keys[2]).GetValue(s, null));
         }
 
         //

--- a/Lib/Helper.cs
+++ b/Lib/Helper.cs
@@ -161,4 +161,17 @@ internal static class Helper
     {
         return FileVersionInfo.GetVersionInfo(GetCurrentAssembly().Location);
     }
+
+    public static object GetMaidStatus(Maid maid) {
+        var type = maid.GetType();
+        PropertyInfo pi = type.GetProperty("Param");
+        var param = (pi != null ? pi.GetValue(maid, null) : maid);
+        return param.GetType().GetProperty("status").GetValue(param, null);
+    }
+
+    public static object GetMaidStatusValue(Maid maid, String propkey) {
+        var status = GetMaidStatus(maid);
+        PropertyInfo pi = status.GetType().GetProperty(propkey);
+        return pi.GetValue(status, null);
+    }
 }

--- a/MaidVoicePitch/SliderTemplates.cs
+++ b/MaidVoicePitch/SliderTemplates.cs
@@ -38,7 +38,7 @@ internal static class SliderTemplates
         }
         string fname = ExSaveData.Get(maid, PluginName, "SLIDER_TEMPLATE", "UnityInjector/Config/MaidVoicePitchSlider.xml");
         SliderTemplate sliderTemplate = sliderTemplates.Get(fname);
-        string guid = maid.status.guid;
+        string guid = (string)Helper.GetMaidStatusValue(maid, "guid");
         if (sliderTemplate != null && !sliderTemplate.LoadedMaidGuids.Contains(guid))
         {
             sliderTemplate.WriteProps(maid);

--- a/MaidVoicePitch/SliderTemplates.cs
+++ b/MaidVoicePitch/SliderTemplates.cs
@@ -38,7 +38,7 @@ internal static class SliderTemplates
         }
         string fname = ExSaveData.Get(maid, PluginName, "SLIDER_TEMPLATE", "UnityInjector/Config/MaidVoicePitchSlider.xml");
         SliderTemplate sliderTemplate = sliderTemplates.Get(fname);
-        string guid = maid.Param.status.guid;
+        string guid = maid.status.guid;
         if (sliderTemplate != null && !sliderTemplate.LoadedMaidGuids.Contains(guid))
         {
             sliderTemplate.WriteProps(maid);


### PR DESCRIPTION
COM3D2対応として行った内容は下記の通りです。

- MaidParamクラスとMaidクラスの統合。maid.Paramがなくなり、maid.Param.statusをmaid.statusで直接とるようになった。
- (暫定的な対応として)CM3D2およびCOM3D2どちらにも対応できるよう、maid.Param.status以下のプロパティを取得するためのヘルパ関数をHelperクラスに作成。ただしパフォーマンス面で不利なのとCM3D2/COM3D2間での書き換え量によっては一つのコードで両対応するより別々に作り直したほうが良いケースもあると思われる。

突然のPRご容赦ください。ご参照いただければ幸いです。